### PR TITLE
More improvements to markdown readme system

### DIFF
--- a/Assets/Readme.md.meta
+++ b/Assets/Readme.md.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: f3ec5fa7ddaf18846ae9841d2ec905b2
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/TutorialInfo/Scripts/Editor/MarkdownRenderer.cs
+++ b/Assets/TutorialInfo/Scripts/Editor/MarkdownRenderer.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System;
+using UnityEditor.VersionControl;
 
 public class MarkdownRenderer
 {
@@ -14,21 +15,25 @@ public class MarkdownRenderer
     private GUIStyle headingStyle1;
     private GUIStyle headingStyle2;
     private GUIStyle headingStyle3;
+    private GUIStyle headingStyle4;
+    private GUIStyle headingStyle5;
+    private GUIStyle headingStyle6;
     private GUIStyle linkStyle;
     private GUIStyle toggleStyle;
     private GUIStyle codeStyle;
-    private GUIStyle listStyle, textArea;
-
+    private GUIStyle listStyle;
+    private GUIStyle quoteStyle;
     private ReadmeEditor readmeEditor;
     private List<Action> cachedGuiCalls = new List<Action>();
     private string lastParsedMarkdown;
     private bool needsReparsing = true;
 
-    public MarkdownRenderer()
-    {
+    public MarkdownRenderer() {
         InitializeStyles();
     }
 
+    public void CacheGUICall(Action _callToCache) => cachedGuiCalls.Add(_callToCache);
+    
     public void SetReadmeEditor(ReadmeEditor _editor)
     {
         readmeEditor = _editor;
@@ -47,21 +52,22 @@ public class MarkdownRenderer
         bodyStyleScratchedOff.fontSize = 14;
         bodyStyleScratchedOff.normal.textColor = Color.gray;
 
-        textArea = new GUIStyle(EditorStyles.textArea);
-
         toggleStyle = new GUIStyle(EditorStyles.toggle);
 
         headingStyle1 = new GUIStyle(bodyStyle);
         headingStyle1.fontSize = 26;
         headingStyle1.fontStyle = FontStyle.Bold;
+        headingStyle1.normal.textColor = new Color(0.98f, 0.98f, 0.98f);
 
         headingStyle2 = new GUIStyle(bodyStyle);
         headingStyle2.fontSize = 20;
         headingStyle2.fontStyle = FontStyle.Bold;
+        headingStyle2.normal.textColor = new Color(0.72f, 0.72f, 0.72f);
 
         headingStyle3 = new GUIStyle(bodyStyle);
         headingStyle3.fontSize = 16;
         headingStyle3.fontStyle = FontStyle.Bold;
+        headingStyle3.normal.textColor = new Color(0.42f, 0.42f, 0.42f);
 
         linkStyle = new GUIStyle(bodyStyle);
         linkStyle.normal.textColor = new Color(0x00 / 255f, 0x78 / 255f, 0xDA / 255f, 1f);
@@ -72,8 +78,53 @@ public class MarkdownRenderer
         codeStyle.fontSize = 12;
         codeStyle.fontStyle = FontStyle.Bold;
 
+        headingStyle4 = new GUIStyle(bodyStyle);
+        headingStyle4.fontSize = 14;
+        headingStyle4.fontStyle = FontStyle.Bold;
+        headingStyle4.normal.textColor = new Color(0.32f, 0.32f, 0.32f);
+
+        headingStyle5 = new GUIStyle(bodyStyle);
+        headingStyle5.fontSize = 12;
+        headingStyle5.fontStyle = FontStyle.Bold;
+        headingStyle5.normal.textColor = new Color(0.22f, 0.22f, 0.22f);
+
+        headingStyle6 = new GUIStyle(bodyStyle);
+        headingStyle6.fontSize = 10;
+        headingStyle6.fontStyle = FontStyle.Bold;
+        headingStyle6.normal.textColor = new Color(0.12f, 0.12f, 0.12f);
+
+        quoteStyle = new GUIStyle(bodyStyle);
+        quoteStyle.normal.textColor = new Color(0.6f, 0.6f, 0.6f);
+
         listStyle = new GUIStyle(bodyStyle);
         listStyle.padding.left = 20;
+    }
+
+    private Texture2D MakeTex(int width, int height, Color col)
+    {
+        Color[] pix = new Color[width * height];
+        for (int i = 0; i < pix.Length; i++)
+        {
+            pix[i] = col;
+        }
+        Texture2D result = new Texture2D(width, height);
+        result.SetPixels(pix);
+        result.Apply();
+        return result;
+    }
+
+    private void CacheQuoteBlock(string text)
+    {
+        CacheGUICall(() => {
+            GUILayout.Space(2);
+            var rectToUse = GUILayoutUtility.GetRect(new GUIContent(text), quoteStyle);
+            // EditorGUILayout.BeginVertical(EditorStyles.helpBox, guiLayoutHeight);
+            EditorGUI.DrawRect(new Rect(rectToUse.x, rectToUse.y, rectToUse.width * 0.98f, rectToUse.height), new Color(0.2f, 0.2f, 0.2f));
+            EditorGUI.DrawRect(new Rect(rectToUse.x, rectToUse.y, EditorGUIUtility.singleLineHeight * 0.2f, rectToUse.height), new Color(0.34f, 0.34f, 0.34f));
+            EditorGUI.LabelField(new Rect(rectToUse.x + EditorGUIUtility.singleLineHeight * 0.9f, rectToUse.y + EditorGUIUtility.singleLineHeight * 0.5f, rectToUse.width * 0.96f, rectToUse.height * 0.95f),text, quoteStyle);
+            // EditorGUILayout.EndVertical();
+            GUILayout.Space(2);
+        });
     }
 
     public void RenderMarkdown(string markdown)
@@ -90,7 +141,7 @@ public class MarkdownRenderer
             {
                 CacheBlock(fileLines[i], i);
             }
-            
+        
             lastParsedMarkdown = markdown;
             needsReparsing = false;
         }
@@ -118,13 +169,29 @@ public class MarkdownRenderer
     bool renderSpaceBeforeNextBlock = false;
     int currentSpaceBetweenBlocks = 5;
     bool modifiedFile = false;
+    private bool isInCodeBlock = false;
+    private bool _lastWasQuoteBlock = false;
+    private bool lastWasQuoteBlock {get => _lastWasQuoteBlock;
+        set {
+            if (value == _lastWasQuoteBlock) return;
+            _lastWasQuoteBlock = value;
+            if (!_lastWasQuoteBlock && quoteBlockContent != null && quoteBlockContent.Length > 0) {
+                CacheQuoteBlock(quoteBlockContent.ToString());
+                codeBlockContent = null;
+            }
+        }
+    }
+    private StringBuilder codeBlockContent;
+    private StringBuilder quoteBlockContent;
     private void CacheBlock(string block, int lineIndex)
     {
         if (string.IsNullOrWhiteSpace(block))
         {
             wasPreviouslyRenderedBlockList = false;
+            lastWasQuoteBlock = false;
             wasPreviouslyRenderedBlockHeader = false;
-            cachedGuiCalls.Add(() => EditorGUILayout.Space(currentSpaceBetweenBlocks));
+            CacheGUICall(() => EditorGUILayout.Space(currentSpaceBetweenBlocks));
+            CacheGUICall(() => EditorGUILayout.LabelField("", bodyStyle)); // Add empty line
             currentSpaceBetweenBlocks = 5;
             return;
         }
@@ -134,8 +201,27 @@ public class MarkdownRenderer
         int extraIndentation = 0;
         block = block.Trim();
 
-        for (int i = 0; i < originalBlock.Length; i++)
-        {
+        // Handle code block start/end
+        if (block.StartsWith("```")) {
+            if (!isInCodeBlock) {
+                isInCodeBlock = true;
+                codeBlockContent = new StringBuilder();
+                // Skip the language identifier if present
+                return;
+            } else {
+                isInCodeBlock = false;
+                CacheCodeBlock(codeBlockContent.ToString());
+                codeBlockContent = null;
+                return;
+            }
+        }
+
+        if (isInCodeBlock) {
+            codeBlockContent.AppendLine(originalBlock);
+            return;
+        }
+
+        for (int i = 0; i < originalBlock.Length; i++) {
             if (originalBlock[i] == '\t') extraIndentation += 4;
             if (block.Length > 0 && originalBlock[i] == block[0])
             {
@@ -145,20 +231,38 @@ public class MarkdownRenderer
         }
 
         bool isList = block.StartsWith("- ") || block.StartsWith("* ");
+        bool isQuoteBlock = block.StartsWith("> ");
+        if (!isQuoteBlock && lastWasQuoteBlock) {
+            lastWasQuoteBlock = false;
+            CacheGUICall(() => EditorGUILayout.Space(5));
+        }
         int drawBefore = wasPreviouslyRenderedBlockHeader && isList ? 0 : currentSpaceBetweenBlocks;
         currentSpaceBetweenBlocks = 5;
 
-        if (isList)
+        if (isList || isQuoteBlock)
         {
-            if (drawBefore > 0 && renderSpaceBeforeNextBlock)
+            if (drawBefore > 0 && renderSpaceBeforeNextBlock && !lastWasQuoteBlock)
             {
                 int spaceToDraw = drawBefore;
-                cachedGuiCalls.Add(() => GUILayout.Space(spaceToDraw));
+                CacheGUICall(() => GUILayout.Space(spaceToDraw));
             }
-
-            CacheListBlock(block, indentationCount, lineIndex);
+        
+            if (isList) {
+                CacheListBlock(block, indentationCount, lineIndex);
+                wasPreviouslyRenderedBlockList = true;
+                lastWasQuoteBlock = false;
+            } else {
+                if (!lastWasQuoteBlock) {
+                    lastWasQuoteBlock = true;
+                    quoteBlockContent = new StringBuilder();
+                }
+                var quoteText = block.Substring(2);
+                if (indentationCount > 0)
+                    quoteText = quoteText.PadLeft(quoteText.Length + indentationCount);
+                quoteBlockContent.AppendLine(quoteText);
+                lastWasQuoteBlock = true;
+            }
             currentSpaceBetweenBlocks = 0;
-            wasPreviouslyRenderedBlockList = true;
             wasPreviouslyRenderedBlockHeader = false;
         }
         else
@@ -166,12 +270,12 @@ public class MarkdownRenderer
             if (drawBefore > 0 && renderSpaceBeforeNextBlock)
             {
                 int spaceToDraw = drawBefore;
-                cachedGuiCalls.Add(() => GUILayout.Space(spaceToDraw));
+                CacheGUICall(() => GUILayout.Space(spaceToDraw));
             }
 
             if (wasPreviouslyRenderedBlockList)
             {
-                cachedGuiCalls.Add(() => GUILayout.Space(currentSpaceBetweenBlocks + 5));
+                CacheGUICall(() => GUILayout.Space(currentSpaceBetweenBlocks + 5));
             }
 
             wasPreviouslyRenderedBlockList = false;
@@ -180,28 +284,46 @@ public class MarkdownRenderer
             if (block.StartsWith("# "))
             {
                 string text = block.Substring(2);
-                cachedGuiCalls.Add(() => RenderHeading(text, headingStyle1, indentationCount, ref renderedHeading));
+                CacheGUICall(() => RenderHeading(text, headingStyle1, indentationCount, ref renderedHeading));
             }
             else if (block.StartsWith("## "))
             {
                 string text = block.Substring(3);
-                cachedGuiCalls.Add(() => RenderHeading(text, headingStyle2, indentationCount, ref renderedHeading));
+                CacheGUICall(() => RenderHeading(text, headingStyle2, indentationCount, ref renderedHeading));
             }
             else if (block.StartsWith("### "))
             {
                 string text = block.Substring(4);
-                cachedGuiCalls.Add(() => RenderHeading(text, headingStyle3, indentationCount, ref renderedHeading));
+                CacheGUICall(() => RenderHeading(text, headingStyle3, indentationCount, ref renderedHeading));
+            }
+            else if (block.StartsWith("#### "))
+            {
+                string text = block.Substring(5);
+                CacheGUICall(() => RenderHeading(text, headingStyle4, indentationCount, ref renderedHeading));
+            }
+            else if (block.StartsWith("##### "))
+            {
+                string text = block.Substring(6);
+                CacheGUICall(() => RenderHeading(text, headingStyle5, indentationCount, ref renderedHeading));
+            }
+            else if (block.StartsWith("###### "))
+            {
+                string text = block.Substring(7);
+                CacheGUICall(() => RenderHeading(text, headingStyle6, indentationCount, ref renderedHeading));
+            }
+            else if (Regex.IsMatch(block, @"^(\*\*\*|---|___|---)$"))
+            {
+                CacheGUICall(() => RenderHorizontalLine());
             }
             else if (block.StartsWith("```"))
             {
-                string codeBlock = block;
-                cachedGuiCalls.Add(() => RenderCodeBlock(codeBlock));
+                CacheCodeBlock(block);
             }
             else
             {
                 string paragraph = block;
                 int indent = indentationCount;
-                cachedGuiCalls.Add(() => RenderParagraph(paragraph, indent));
+                CacheParagraph(paragraph, indent);
             }
 
             wasPreviouslyRenderedBlockHeader = renderedHeading;
@@ -214,10 +336,12 @@ public class MarkdownRenderer
     {
         text = ProcessInlineFormatting(text);
         EditorGUILayout.LabelField(text, style);
+        if (style == headingStyle1 || style == headingStyle2)
+            RenderHorizontalLine(1f);
         renderedHeading = true;
     }
 
-    private void RenderParagraph(string text, int indentationCount)
+    private void CacheParagraph(string text, int indentationCount)
     {
         if (string.IsNullOrEmpty(text.Trim()))
         {
@@ -229,46 +353,56 @@ public class MarkdownRenderer
         var segments = SplitTextIntoSegments(text);
         if (indentationCount > 0)
         {
-            EditorGUILayout.BeginHorizontal();
-            EditorGUILayout.Space(indentationCount);
+            CacheGUICall(() => {
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.Space(indentationCount);
+            });
         }
-        EditorGUILayout.BeginVertical();
-        var lineContent = new StringBuilder();
 
+        CacheGUICall(() => { EditorGUILayout.BeginVertical(); });
         foreach (var segment in segments)
         {
+            if (segment.isImage)
+            {
+                var texture = AssetDatabase.LoadAssetAtPath<Texture2D>(segment.target);
+                if (texture != null)
+                {
+                    CacheGUICall(() => {
+                        float maxWidth = EditorGUIUtility.currentViewWidth - 40;
+                        float aspectRatio = (float)texture.width / texture.height;
+                        float width = Mathf.Min(maxWidth, texture.width);
+                        float height = width / aspectRatio;
+                        
+                        GUILayout.Box(texture, GUILayout.Width(width), GUILayout.Height(height));
+                    });
+                }
+                continue;
+            }
+
             if (segment.isLink)
             {
-                // Flush any accumulated regular text
-                if (lineContent.Length > 0)
-                {
-                    EditorGUILayout.LabelField(lineContent.ToString(), bodyStyle);
-                    lineContent.Clear();
-                }
-
-                // Render the link
-                if (LinkLabel(new GUIContent(segment.displayText)))
-                {
-                    HandleLinkClick(segment.linkType, segment.target);
-                }
+                CacheGUICall(() => {
+                    if (LinkLabel(new GUIContent(segment.displayText)))
+                    {
+                        HandleLinkClick(segment.linkType, segment.target);
+                    }
+                });
             }
             else
             {
-                lineContent.Append(segment.text);
+                string textSegment = segment.text;
+                CacheGUICall(() => {
+                    EditorGUILayout.LabelField(textSegment, bodyStyle);
+                });
             }
         }
 
-        // Flush any remaining text
-        if (lineContent.Length > 0)
-        {
-            EditorGUILayout.LabelField(lineContent.ToString(), bodyStyle);
-        }
 
-        EditorGUILayout.EndVertical();
-
+        CacheGUICall(() => { EditorGUILayout.EndVertical(); });
+        
         if (indentationCount > 0)
         {
-            EditorGUILayout.EndHorizontal();
+            CacheGUICall(() => { EditorGUILayout.EndHorizontal(); });
         }
     }
 
@@ -276,6 +410,7 @@ public class MarkdownRenderer
     {
         public string text;
         public bool isLink;
+        public bool isImage;
         public string linkType;
         public string target;
         public string displayText;
@@ -285,7 +420,8 @@ public class MarkdownRenderer
     {
         var segments = new List<TextSegment>();
         var linkPattern = @"<link=""(.+?):(.+?)"">(.*?)</link>";
-        var matches = Regex.Matches(text, linkPattern);
+        var imagePattern = @"<image=(.+?)>";
+        var matches = Regex.Matches(text, $"{linkPattern}|{imagePattern}");
         int lastIndex = 0;
 
         foreach (Match match in matches)
@@ -300,14 +436,24 @@ public class MarkdownRenderer
                 });
             }
 
-            // Add the link
-            segments.Add(new TextSegment
+            if (match.Groups[1].Success) // Link
             {
-                isLink = true,
-                linkType = match.Groups[1].Value,
-                target = match.Groups[2].Value,
-                displayText = match.Groups[3].Value
-            });
+                segments.Add(new TextSegment
+                {
+                    isLink = true,
+                    linkType = match.Groups[1].Value,
+                    target = match.Groups[2].Value,
+                    displayText = match.Groups[3].Value
+                });
+            }
+            else if (match.Groups[4].Success) // Image
+            {
+                segments.Add(new TextSegment
+                {
+                    isImage = true,
+                    target = match.Groups[4].Value
+                });
+            }
 
             lastIndex = match.Index + match.Length;
         }
@@ -366,101 +512,6 @@ public class MarkdownRenderer
         return GUI.Button(position, label, linkStyle);
     }
 
-    private void RenderCodeBlock(string block)
-    {
-        var lines = block.Split('\n');
-        var code = string.Join("\n",
-            lines.Skip(1).Take(lines.Length - 2)); // Remove ``` lines
-
-        EditorGUILayout.TextArea(code, codeStyle);
-    }
-
-    private void RenderList(string block, int indentationCount, int lineIndex)
-    {
-        var items = block.Split('\n')
-            .Where(line => line.StartsWith("- ") || line.StartsWith("* "))
-            .Select(line => line.Substring(2));
-
-        foreach (var item in items)
-        {
-            EditorGUILayout.BeginHorizontal();
-            if (indentationCount > 0)
-                EditorGUILayout.Space(indentationCount * 5.0f, false);
-
-            readmeEditor.showingSpecialBackgroundColor = false;
-
-            bool drewToggle = false;
-            bool toggleStatus = false;
-            string useLine = item;
-            if (useLine.StartsWith("[ ]"))
-                useLine = DrawToggle(useLine, false, ref drewToggle, 3, lineIndex);
-            else if (useLine.StartsWith("[]"))
-                useLine = DrawToggle(useLine, false, ref drewToggle, 2, lineIndex);
-            else if (useLine.StartsWith("[x]"))
-            { 
-                useLine = DrawToggle(useLine, true, ref drewToggle, 3, lineIndex);
-                toggleStatus = true;
-            }
-
-            readmeEditor.showingSpecialBackgroundColor = true;
-
-            if (!drewToggle)
-                EditorGUILayout.LabelField("", GUILayout.Width(15));
-
-            var segments = SplitTextIntoSegments(ProcessInlineFormatting(useLine));
-            var lineContent = new StringBuilder();
-            
-            foreach (var segment in segments)
-            {
-                if (segment.isLink)
-                {
-                    // Flush any accumulated regular text
-                    if (lineContent.Length > 0)
-                    {
-                        EditorGUILayout.LabelField(lineContent.ToString(), bodyStyle);
-                        lineContent.Clear();
-                    }
-
-                    // Render the link
-                    if (LinkLabel(new GUIContent(segment.displayText)))
-                    {
-                        HandleLinkClick(segment.linkType, segment.target);
-                    }
-                }
-                else
-                {
-                    lineContent.Append(segment.text);
-                }
-            }
-
-            // Flush any remaining text
-            if (lineContent.Length > 0)
-            {
-                if (drewToggle && toggleStatus) {
-                    string strikethrough = "";
-                    bool foundFirstNonSpace = false;
-                    foreach (char c in lineContent.ToString())
-                    {
-                        if (c != ' ' || foundFirstNonSpace)
-                        {
-                            strikethrough = strikethrough + c + ('\u0336');
-                            foundFirstNonSpace = true;
-                        }
-                        else{
-                            strikethrough = strikethrough + c;
-                        }
-                    }
-                    EditorGUILayout.LabelField(strikethrough, bodyStyleScratchedOff);
-
-                } else
-                {
-                    EditorGUILayout.LabelField(lineContent.ToString(), bodyStyle);
-                }
-            }
-            EditorGUILayout.EndHorizontal();
-        }
-    }
-
     private string ProcessInlineFormatting(string text)
     {
         // Bold
@@ -474,7 +525,112 @@ public class MarkdownRenderer
         // Inline code
         text = Regex.Replace(text, @"`(.+?)`", "<color=#bdc4cb><b>$1</b></color>");
 
-        // Unity asset links with special syntax: [[WikiPage:path/to/asset]] or [[File:path/to/file]]
+        // Handle images and links
+        text = Regex.Replace(text, @"(!?)\[(.+?)\]\((.+?)\)", match => {
+            var isImage = match.Groups[1].Value == "!";
+            var altText = match.Groups[2].Value;
+            var path = match.Groups[3].Value;
+
+            // Skip URLs
+            if (path.StartsWith("http://") || path.StartsWith("https://"))
+            {
+                if (isImage)
+                {
+                    // TODO: Could add web image loading here if needed
+                    return $"<color=grey>[External Image: {altText}]</color>";
+                }
+                return $"<link=\"url:{path}\">{altText}</link>";
+            }
+
+            // Check for .asset file
+            string assetPath = path;
+            var asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath);
+            if (asset == null)
+            {
+                // Handle paths that start with a forward slash by treating them as relative to Assets/
+                if (path.StartsWith("/"))
+                {
+                    assetPath = "Assets" + path;
+                    asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath);
+                    if (asset != null)
+                    {
+                        path = assetPath;
+                    }
+                }
+                // Try adding Assets/ prefix if not present
+                else if (!path.StartsWith("Assets/"))
+                {
+                    assetPath = "Assets/" + path;
+                    asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath);
+                    if (asset != null)
+                    {
+                        path = assetPath;
+                    }
+                }
+
+                // If still not found, try relative to current file
+                if (asset == null && readmeEditor?.target != null)
+                {
+                    try
+                    {
+                        string currentFilePath = AssetDatabase.GetAssetPath(readmeEditor.target);
+                        string currentDir = Path.GetDirectoryName(currentFilePath);
+                        string fullPath = Path.GetFullPath(Path.Combine(currentDir, path.TrimStart('/')));
+                        
+                        // Normalize paths for comparison
+                        string normalizedFullPath = Path.GetFullPath(fullPath).Replace('\\', '/');
+                        string normalizedDataPath = Path.GetFullPath(Application.dataPath).Replace('\\', '/');
+                        
+                        // Only proceed if the path is within the Assets folder
+                        if (normalizedFullPath.StartsWith(normalizedDataPath, StringComparison.OrdinalIgnoreCase))
+                        {
+                            string relativePath = "Assets" + normalizedFullPath.Substring(normalizedDataPath.Length).Replace('\\', '/');
+                            asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(relativePath);
+                            if (asset != null)
+                            {
+                                path = relativePath;
+                            }
+                        }
+                    }
+                    catch (ArgumentException)
+                    {
+                        Debug.LogWarning($"Invalid path characters in: {path}");
+                    }
+                }
+            }
+
+            // Debug.Log($"Asset path {assetPath} asset {(asset != null ? asset.GetType().Name : "Null")}");
+            if (asset != null)
+            {
+                if (asset is TextAsset) {
+                    string tryWikiPath = Path.ChangeExtension(assetPath, ".asset");
+                    var wikiAsset = AssetDatabase.LoadAssetAtPath<WikiPage>(tryWikiPath);
+                    if (wikiAsset != null) {
+                        asset = wikiAsset;
+                        assetPath = tryWikiPath;
+                    }
+                    // Debug.Log($"Asset path {assetPath} asset {(asset != null ? asset.GetType().Name : "Null")}");
+                }
+                if (isImage && asset is Texture2D)
+                {
+                    return $"<image={path}>";  // Special tag we'll handle in rendering
+                }
+                else if (asset is WikiPage)
+                {
+                    string displayTitle = !string.IsNullOrEmpty(altText) ?  altText : (!string.IsNullOrEmpty((asset as WikiPage).title) ? (asset as WikiPage).title : Path.GetFileNameWithoutExtension(path));
+                    return $"<link=\"asset:{assetPath}\">{displayTitle}</link>";
+                }
+                return $"<link=\"file:{path}\">{altText}</link>";
+            }
+            
+            // Asset not found
+            if (isImage)
+            {
+                return $"<color=red>[Missing Image: {path}]</color>";
+            }
+            return $"<link=\"url:{path}\">{altText}</link>";
+        });
+
         text = Regex.Replace(text, @"\[\[WikiPage:(.+?)\]\]", match => {
             var path = "Assets/" + match.Groups[1].Value;
             if (!path.Contains("."))
@@ -482,7 +638,8 @@ public class MarkdownRenderer
             var asset = AssetDatabase.LoadAssetAtPath<WikiPage>(path.TrimStart().TrimEnd());
             if (asset != null)
             {
-                return $"<link=\"asset:{path}\">{asset.title}</link>";
+                string displayTitle = !string.IsNullOrEmpty(asset.title) ? asset.title : Path.GetFileNameWithoutExtension(path);
+                return $"<link=\"asset:{path}\">{displayTitle}</link>";
             }
             return $"<color=red>Missing: {path}</color>";
         });
@@ -497,41 +654,80 @@ public class MarkdownRenderer
             return $"<color=red>Missing: {path}</color>";
         });
 
-        // Regular markdown links
-        text = Regex.Replace(text, @"\[(.+?)\]\((.+?)\)", "<link=\"url:$2\">$1</link>");
-
         return text;
     }
 
-    public bool HandleLinks(string text, Vector2 position)
+    private void CacheCodeBlock(string code)
     {
-        var linkMatches = Regex.Matches(text, @"\[(.+?)\]\((.+?)\)");
-        foreach (Match match in linkMatches)
-        {
-            var linkText = match.Groups[1].Value;
-            var url = match.Groups[2].Value;
+        // C# keywords to highlight
+        string[] keywords = new string[] {
+            "public", "private", "protected", "internal", "class", "struct", "interface",
+            "void", "string", "int", "float", "bool", "var", "new", "return", "if", "else",
+            "for", "foreach", "while", "do", "switch", "case", "break", "continue", "static",
+            "readonly", "const", "using", "namespace", "ref", "out", "in", "null", "true", "false", "base", "override", "virtual", "sealed", "abstract", "event", "delegate", "enum", "struct", "interface", "class", "struct", "interface", "this",
+            "using", "namespace", "ref", "out", "in", "null", "true", "false"
+        };
 
-            // Calculate link position and check if clicked
-            var linkRect = GUILayoutUtility.GetLastRect();
-            if (Event.current.type == EventType.MouseDown &&
-                linkRect.Contains(Event.current.mousePosition))
+        var lineContent = new StringBuilder();
+        var lines = code.Split('\n');
+        int linesCount = lines.Length;
+        lineContent.AppendLine(" ");
+        
+        foreach (var line in lines)
+        {
+            string processedLine = line;
+
+            // Handle comments first
+            int commentIndex = line.IndexOf("//");
+            string comment = "";
+            if (commentIndex >= 0)
             {
-                if (url.StartsWith("http"))
-                {
-                    Application.OpenURL(url);
-                    return true;
-                }
-                // Handle internal page links here
+                comment = line.Substring(commentIndex);
+                processedLine = line.Substring(0, commentIndex);
             }
+
+            // Highlight keywords
+            foreach (var keyword in keywords)
+            {
+                processedLine = Regex.Replace(
+                    processedLine,
+                    $@"\b{keyword}\b",
+                    $"<color=#569CD6>{keyword}</color>"
+                );
+            }
+
+            // Handle string literals
+            processedLine = Regex.Replace(
+                processedLine,
+                "\".*?\"",
+                m => $"<color=#CE9178>{m.Value}</color>"
+            );
+
+            // Add back comments with different color
+            if (!string.IsNullOrEmpty(comment))
+            {
+                processedLine += $"<color=#57A64A>{comment}</color>";
+            }
+            
+            lineContent.AppendLine(processedLine);
         }
-        return false;
+
+        string finalContent = lineContent.ToString();
+        CacheGUICall(() => {
+            GUILayout.Space(2);
+            var rectToUse = GUILayoutUtility.GetRect(new GUIContent(finalContent), bodyStyle);
+            // EditorGUILayout.BeginVertical(EditorStyles.helpBox, guiLayoutHeight);
+            EditorGUI.DrawRect(new Rect(rectToUse.x, rectToUse.y, rectToUse.width * 0.98f, rectToUse.height), new Color(0.2f, 0.2f, 0.2f));
+            EditorGUI.SelectableLabel(new Rect(rectToUse.x + EditorGUIUtility.singleLineHeight * 0.4f, rectToUse.y + EditorGUIUtility.singleLineHeight * 0.5f, rectToUse.width * 0.96f, rectToUse.height * 0.95f),finalContent, bodyStyle);
+            
+            // EditorGUILayout.EndVertical();
+            GUILayout.Space(2);
+        });
     }
 
-    string DrawToggle(string useLine, bool status, ref bool _drewToggle, int uselineSubstring = 3, int lineIndex = -1)
+    void DrawToggle(string useLine, bool status, int lineIndex = -1)
     {
         bool newToggleValue = EditorGUILayout.Toggle(status, toggleStyle, GUILayout.Width(15));
-        useLine = useLine.Substring(uselineSubstring);
-        _drewToggle = true;
         if (newToggleValue != status && lineIndex > 0 && lineIndex < fileLines.Count)
         {
             if (newToggleValue)
@@ -545,8 +741,34 @@ public class MarkdownRenderer
             }
             modifiedFile = true;
         }
-        return useLine;
     }
+    // public static readonly Color DEFAULT_COLOR = new Color(0f, 0f, 0f, 0.3f);
+    public static readonly Vector2 DEFAULT_LINE_MARGIN = new Vector2(2f, 2f);
+
+    // public const float DEFAULT_LINE_HEIGHT = 1f;
+
+    // public static void HorizontalLine(Color color, float height, Vector2 margin)
+    // {
+    //     GUILayout.Space(margin.x);
+
+    //     EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, height), color);
+
+    //     GUILayout.Space(margin.y);
+    // }
+    private void RenderHorizontalLine(Color color, float height, Vector2 margin)
+    {
+        GUILayout.Space(margin.x);
+        EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, height), color);
+        GUILayout.Space(margin.y);
+    }
+
+    private void RenderHorizontalLine(Color color, float height = 2f) {
+        RenderHorizontalLine(color, height, new Vector2(2f,2f));
+    }
+    private void RenderHorizontalLine(float height = 2f) {
+        RenderHorizontalLine(Color.gray, height, new Vector2(2f,2f));
+    }
+
     private void CacheListBlock(string block, int indentationCount, int lineIndex)
     {
         var items = block.Split('\n')
@@ -559,82 +781,91 @@ public class MarkdownRenderer
             int capturedIndent = indentationCount;
             int capturedLineIndex = lineIndex;
 
-            cachedGuiCalls.Add(() => {
+            CacheGUICall(() => {
                 EditorGUILayout.BeginHorizontal();
-                if (capturedIndent > 0)
-                    EditorGUILayout.Space(capturedIndent * 5.0f, false);
-
                 readmeEditor.showingSpecialBackgroundColor = false;
+            });
+            if (capturedIndent > 0) {
+                CacheGUICall(() => { EditorGUILayout.Space(capturedIndent * 5.0f, false); });
+            }
 
-                bool drewToggle = false;
-                bool toggleStatus = false;
-                string useLine = capturedItem;
-                
-                if (useLine.StartsWith("[ ]"))
-                    useLine = DrawToggle(useLine, false, ref drewToggle, 3, capturedLineIndex);
-                else if (useLine.StartsWith("[]"))
-                    useLine = DrawToggle(useLine, false, ref drewToggle, 2, capturedLineIndex);
-                else if (useLine.StartsWith("[x]"))
-                { 
-                    useLine = DrawToggle(useLine, true, ref drewToggle, 3, capturedLineIndex);
-                    toggleStatus = true;
-                }
-
-                readmeEditor.showingSpecialBackgroundColor = true;
-
-                if (!drewToggle)
-                    EditorGUILayout.LabelField("•", GUILayout.Width(15));
-
-                var segments = SplitTextIntoSegments(ProcessInlineFormatting(useLine));
-                var lineContent = new StringBuilder();
-                
-                foreach (var segment in segments)
+            bool isMarkedToggle = capturedItem.ToLower().StartsWith("[x]");
+            bool isUnmarkedToggle = capturedItem.StartsWith("[ ]") || capturedItem.StartsWith("[]");
+            if (isUnmarkedToggle) {
+                capturedItem = capturedItem.Substring(capturedItem.StartsWith("[ ]") ? 3 : 2);
+            } else if (isMarkedToggle) {
+                capturedItem = capturedItem.Substring(3);
+            }
+            if (isMarkedToggle || isUnmarkedToggle) {
+                CacheGUICall(() => {
+                    readmeEditor.showingSpecialBackgroundColor = true;
+                    DrawToggle(capturedItem, isMarkedToggle, capturedLineIndex);
+                });
+            } else {
+                CacheGUICall(() => {
+                        EditorGUILayout.LabelField("•", GUILayout.Width(15));
+                    });
+            }
+            var segments = SplitTextIntoSegments(ProcessInlineFormatting(capturedItem));
+            var lineContent = new StringBuilder();
+            
+            foreach (var segment in segments)
+            {
+                if (segment.isLink)
                 {
-                    if (segment.isLink)
+                    // Flush any accumulated regular text
+                    if (lineContent.Length > 0)
                     {
-                        // Flush any accumulated regular text
-                        if (lineContent.Length > 0)
-                        {
+                        CacheGUICall(() => {
+                            readmeEditor.showingSpecialBackgroundColor = false;
                             EditorGUILayout.LabelField(lineContent.ToString(), bodyStyle);
-                            lineContent.Clear();
-                        }
+                        });
+                        lineContent.Clear();
+                    }
 
-                        // Render the link
+                    // Render the link
+                    CacheGUICall(() => { 
                         if (LinkLabel(new GUIContent(segment.displayText)))
                         {
                             HandleLinkClick(segment.linkType, segment.target);
                         }
-                    }
-                    else
-                    {
-                        lineContent.Append(segment.text);
-                    }
+                    });
                 }
-
-                // Flush any remaining text
-                if (lineContent.Length > 0)
+                else
                 {
-                    if (drewToggle && toggleStatus) {
-                        string strikethrough = "";
-                        bool foundFirstNonSpace = false;
-                        foreach (char c in lineContent.ToString())
-                        {
-                            if (c != ' ' || foundFirstNonSpace)
-                            {
-                                strikethrough = strikethrough + c + ('\u0336');
-                                foundFirstNonSpace = true;
-                            }
-                            else{
-                                strikethrough = strikethrough + c;
-                            }
-                        }
-                        EditorGUILayout.LabelField(strikethrough, bodyStyleScratchedOff);
-                    } 
-                    else
-                    {
-                        EditorGUILayout.LabelField(lineContent.ToString(), bodyStyle);
-                    }
+                    lineContent.Append(segment.text);
                 }
+            }
+
+            // Flush any remaining text
+            if (lineContent.Length > 0)
+            {
+                if (isMarkedToggle) {
+                    string strikethrough = "";
+                    bool foundFirstNonSpace = false;
+                    foreach (char c in lineContent.ToString())
+                    {
+                        if (c != ' ' || foundFirstNonSpace)
+                        {
+                            strikethrough = strikethrough + c + ('\u0336');
+                            foundFirstNonSpace = true;
+                        }
+                        else{
+                            strikethrough = strikethrough + c;
+                        }
+                    }
+                    CacheGUICall(() => {
+                        EditorGUILayout.LabelField(strikethrough, bodyStyleScratchedOff);
+                    });
+                } 
+                else
+                {
+                    CacheGUICall(() => {
+                    EditorGUILayout.LabelField(lineContent.ToString(), bodyStyle);
+                    });
+                }
+            }
+            CacheGUICall(() => {
                 EditorGUILayout.EndHorizontal();
             });
         }

--- a/Assets/TutorialInfo/Scripts/Editor/ReadmeEditor.cs
+++ b/Assets/TutorialInfo/Scripts/Editor/ReadmeEditor.cs
@@ -125,6 +125,18 @@ public class ReadmeEditor : Editor
         }
     }
 
+    private string GetMarkdownFilePath(UnityEngine.Object target)
+    {
+        string assetPath = AssetDatabase.GetAssetPath(target);
+        string mdPath = Path.ChangeExtension(assetPath,".md");
+        if (!File.Exists(mdPath) && Path.GetDirectoryName(assetPath) == "Assets") {
+            // If the .md file is not found in the same directory and the asset is in the root Assets folder,
+            // look for the .md file in the project root
+            mdPath = Path.Combine(Directory.GetParent(Application.dataPath).FullName, Path.GetFileNameWithoutExtension(assetPath) + ".md");
+        }
+
+        return mdPath;
+    }
     protected override void OnHeaderGUI()
     {
         showingSpecialBackgroundColor = false;
@@ -148,8 +160,7 @@ public class ReadmeEditor : Editor
             GUILayout.Space(k_Space);
         }
         if (currentlyEditing && GUILayout.Button("Open .md", EditorStyles.miniButton, GUILayout.Width(80))) {
-            string assetPath = AssetDatabase.GetAssetPath(target);
-            string mdPath = Path.ChangeExtension(assetPath, ".md");
+            string mdPath = GetMarkdownFilePath(target);
             if (File.Exists(mdPath)) {
                 AssetDatabase.OpenAsset(AssetDatabase.LoadAssetAtPath<TextAsset>(mdPath));
             }
@@ -159,8 +170,7 @@ public class ReadmeEditor : Editor
             currentlyEditing = !currentlyEditing;
             if (currentlyEditing)
             {
-                string assetPath = AssetDatabase.GetAssetPath(target);
-                string mdPath = Path.ChangeExtension(assetPath, ".md");
+                string mdPath = GetMarkdownFilePath(target);
              
                 if (File.Exists(mdPath))
                 {
@@ -177,8 +187,7 @@ public class ReadmeEditor : Editor
             {
                 if (changedMDEditing)
                 {
-                    string assetPath = AssetDatabase.GetAssetPath(target);
-                    string mdPath = Path.ChangeExtension(assetPath, ".md");
+                    string mdPath = GetMarkdownFilePath(target);
                     File.WriteAllText(mdPath, currentMDEditing);
                     markdownContent.stringValue = null;
                     serializedObject.ApplyModifiedProperties();
@@ -310,8 +319,7 @@ public class ReadmeEditor : Editor
 
         // Try to load markdown content from external file
         string markdownContent = wikiPage.markdownContent;
-        string assetPath = AssetDatabase.GetAssetPath(wikiPage);
-        string mdPath = Path.ChangeExtension(assetPath, ".md");
+        string mdPath = GetMarkdownFilePath(wikiPage);
 
         if (File.Exists(mdPath))
         {
@@ -365,8 +373,7 @@ public class ReadmeEditor : Editor
             Repaint();
             if (!string.IsNullOrEmpty(dirtyFileContent))
             {
-                string getAssetPath = AssetDatabase.GetAssetPath(wikiPage);
-                string getMdPath = Path.ChangeExtension(assetPath, ".md");
+                string getMdPath = GetMarkdownFilePath(wikiPage);
                 File.WriteAllText(getMdPath, dirtyFileContent);
                 dirtyFileContent = "";
             }

--- a/Readme.md
+++ b/Readme.md
@@ -1,13 +1,11 @@
-## Welcome to the Level Tutorial Assignment!
+# Welcome to the Level Tutorial Assignment!
 This template includes the settings and assets you need to start creating with the Universal Render Pipeline.
 
 ## Learn More:
-- [[WikiPage:TutorialInfo/GettingStarted]]
+- [Getting Started](Assets/TutorialInfo/GettingStarted.md) 
 
 ## References:
 - [The Level Design Book](https://book.leveldesignbook.com/)
-
-
 
 ## Assets used licensed under CC0:
 - [Kay Lousberg Mini-Game Variety Pack](https://kaylousberg.itch.io/kay-kit-mini-game-variety-pack)


### PR DESCRIPTION
The Markdown Rendering system now supports code blocks, quote blocks, images, mote headings, different colors for headings, lines, lines under headings 1 and 2, better indentation on lists and more. All with caching of expensive parsing operations.

I also included handling for when the Readme.MD is on the main folder of the project (as is usually the case with github) and make the handling of linking to other .md use the same method as handling regular links so ideally when using links for .md on github it can work in the inspector mode as well.